### PR TITLE
chore(apply_discount): set categories to calc discount

### DIFF
--- a/routes/apply_discount.js
+++ b/routes/apply_discount.js
@@ -78,6 +78,28 @@ const schema = {
             'minimum': 0,
             'maximum': 999999999,
             'description': 'Final item price including additions due to customizations and gift wrap'
+          },
+          'categories': {
+            'type': 'array',
+            'maxItems': 50,
+            'items': {
+              'type': 'object',
+              'additionalProperties': false,
+              'required': [ '_id' ],
+              'properties': {
+                '_id': {
+                  'type': 'string',
+                  'pattern': '^[a-f0-9]{24}$',
+                  'description': 'Category ID'
+                },
+                'name': {
+                  'type': 'string',
+                  'maxLength': 255,
+                  'description': 'Category name'
+                }
+              },
+              'description': 'Category from cart item'
+            }
           }
         },
         'description': 'One of the cart items'


### PR DESCRIPTION
When a store needs to create a campaign and has a lot of products to include in that campaign, two issues arise. First, it is inconvenient for shoppers to insert all the product IDs into the app. Second, when there are numerous products, the app doesn't function properly. Therefore, if we can have one category, we can avoid dealing with a lengthy list of hundreds of IDs.